### PR TITLE
Update help.md

### DIFF
--- a/_docs/help.md
+++ b/_docs/help.md
@@ -1,7 +1,7 @@
 ---
 title:  "寻求帮助"
-permalink: /help.html
-date:   2021-10-09 23:18:02 +0800
+permalink: /help
+date:   2023-08-09 11:12:00 +0800
 categories: 启动器
 toc: true
 ---
@@ -27,9 +27,10 @@ Hello Minecraft! Launcher 的官方 Discord 频道。
 前往爱发电赞助 HMCL。赞助后可以申请加入官方 QQ 群反馈问题。
 
 [点击前往](https://afdian.net/@huanghongxun)
-
+<!--
 ## Bug 反馈
 
 反馈一个错误。为了提高反馈效率，请优先在 KOOK、赞助频道或者 Discord 频道中反馈。若确认是 HMCL 问题，请发布 issue。
 
-[点击前往](https://github.com/huanghongxun/HMCL/issues/new?assignees=&labels=bug&template=bug-report.yml)
+[点击前往](https://github.com/huanghongxun/HMCL/issues/new/choose)
+-->

--- a/_docs/help_old.md
+++ b/_docs/help_old.md
@@ -1,0 +1,36 @@
+---
+title:  "寻求帮助"
+permalink: /help.html
+date:   2023-08-09 11:12:00 +0800
+categories: 启动器
+toc: true
+---
+
+![Hits](https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fdocs.hmcl.net%2Fhelp.html&count_bg=%233E4245&title_bg=%233E4245&icon=&icon_color=%23E7E7E7&title=%F0%9F%91%80&edge_flat=false)
+
+> 本文由 zkitefly 编写。
+
+## KOOK 频道
+
+Hello Minecraft! Launcher 的官方 KOOK 频道。
+
+[点击前往](https://kook.top/Kx7n3t)
+
+## Discord 频道
+
+Hello Minecraft! Launcher 的官方 Discord 频道。
+
+[点击前往](https://discord.gg/jVvC7HfM6U)
+
+## 赞助通道
+
+前往爱发电赞助 HMCL。赞助后可以申请加入官方 QQ 群反馈问题。
+
+[点击前往](https://afdian.net/@huanghongxun)
+<!--
+## Bug 反馈
+
+反馈一个错误。为了提高反馈效率，请优先在 KOOK、赞助频道或者 Discord 频道中反馈。若确认是 HMCL 问题，请发布 issue。
+
+[点击前往](https://github.com/huanghongxun/HMCL/issues/new/choose)
+-->


### PR DESCRIPTION
- 注释掉 GitHub 通道，在 KOOK 和 Discord 反馈之后，我们再让他去 GitHub 提。主要问题在于绝大部分用户分不清“Minecraft 崩溃”和“HMCL”错误
- 将 permalink 改成 `help` ，这样链接就变成了 https://docs.hmcl.net/help ，省掉 .html ，而且以前的 https://docs.hmcl.net/help.html 也是能用的（以防万一，你可以测试下，我这边测试是ok的）
